### PR TITLE
Fix drop shadows

### DIFF
--- a/dist/my-component.js
+++ b/dist/my-component.js
@@ -15,6 +15,7 @@
     window.ByuCard = ByuCard;
 
 })(`<style>:host {
+  display: inline-block;
   background-color: #fff;
   padding: 15px;
   -moz-box-shadow: 0 8px 12px rgba(0, 0, 0, 0.2);

--- a/my-component/style.css
+++ b/my-component/style.css
@@ -1,4 +1,5 @@
 :host {
+  display: inline-block;
   background-color: #fff;
   padding: 15px;
   -moz-box-shadow: 0 8px 12px rgba(0, 0, 0, 0.2);

--- a/my-component/style.scss
+++ b/my-component/style.scss
@@ -5,6 +5,7 @@ $navy: #002E5D;
 
 // :host refers to the custom element, in our case that is <my-proile>...</my-profile>
 :host {
+	display: inline-block;
 	background-color: #fff;
 	padding: 15px;
 	-moz-box-shadow: 0 8px 12px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
:host needs `display: inline-block` or `display-block` in order to render the shadows in the proper location. By default, `display` is `inline`, which won't render the drop shadows properly.