### PR TITLE
Fix overflowing card content

### DIFF
--- a/my-component/demo.html
+++ b/my-component/demo.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 <!-- the styling with flex should occur with the container you put your cards in, like this: -->
-<div class="card-container" style="display: flex; flex-wrap: true; justify-content: space-between;">
+<div class="card-container" style="display: flex; flex-wrap: wrap; justify-content: space-between;">
 	<byu-card style="width: 30%;" >
 
 		<h2>Title of Page Here</h2>

--- a/my-component/mixins.scss
+++ b/my-component/mixins.scss
@@ -31,6 +31,7 @@ $navy: #002E5D;
 
 @mixin cardContentSlotted() {
 	width: 100%;
+	box-sizing: border-box;
 	padding: 0 20px !important;
 	color: #444;
 }


### PR DESCRIPTION
For some reason, I can't get this pull request to only contain 9b9a1eb, but it looks like you've already accepted 079ff40.

Before (notice how close the text is to the edge):
![screenshot from 2017-06-07 10-07-55](https://user-images.githubusercontent.com/2270816/26894468-c4918c72-4b7b-11e7-94a9-4166313764f3.png)

After:
![screenshot from 2017-06-07 12-25-25](https://user-images.githubusercontent.com/2270816/26894720-7b64c022-4b7c-11e7-829f-0ddb710452e6.png)
